### PR TITLE
Correct resourceRequirements in Fargate example

### DIFF
--- a/examples/fargate/main.tf
+++ b/examples/fargate/main.tf
@@ -129,8 +129,8 @@ module "batch" {
           platformVersion = "LATEST"
         },
         resourceRequirements = [
-          { type = "VCPU", value = 1 },
-          { type = "MEMORY", value = 1024 }
+          { type = "VCPU", value = "1" },
+          { type = "MEMORY", value = "2048" }
         ],
         executionRoleArn = aws_iam_role.ecs_task_execution_role.arn
         logConfiguration = {


### PR DESCRIPTION
It fixes 2 bugs:

> Error: AWS Batch Job container_properties is invalid: Error decoding JSON: json: cannot unmarshal number into Go struct field ResourceRequirement.ResourceRequirements.Value of type string

and

> Error: error creating Batch Job Definition (batch-ex-fargate): : Error executing request, Exception : Fargate resource requirements (1.00 vCPU, 1024 MiB) not valid.,